### PR TITLE
update workflows to allow use of secrets

### DIFF
--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
+    secrets:
+      EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
+      EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
 
   deploy:
     needs: build

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -1,10 +1,16 @@
 name: trigger-book-build
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled, synchronize]
+    branches:
+      - main
 
 jobs:
   build:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
+    secrets:
+      EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
+      EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
     with:
       artifact_name: book-zip-${{ github.event.number }}
       base_url: '/${{ github.event.repository.name }}/_preview/${{ github.event.number }}'


### PR DESCRIPTION
I am running into the problem in #8 of repository secrets not being passed to the workflows (the `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` secrets are available in the repo as I created them). I _think_ if we change the triggering event to `pull_request_target` from `pull_request` we can use repository secrets for PRs coming from outside of the organization.