### PR TITLE
Render external myst resources

### DIFF
--- a/additional-resources.md
+++ b/additional-resources.md
@@ -1,0 +1,2 @@
+:::{include} xref:awesome#awesome-icesat2
+:::

--- a/additional-resources.md
+++ b/additional-resources.md
@@ -1,2 +1,0 @@
-:::{include} xref:awesome#awesome-icesat2
-:::

--- a/additional-resources/awesome.md
+++ b/additional-resources/awesome.md
@@ -1,0 +1,6 @@
+# Awesome ICESat-2
+
+The following page is rendered from https://icesat-2hackweek.github.io/awesome-icesat2/
+
+:::{embed} xref:awesome
+:::

--- a/additional-resources/cryocloud.md
+++ b/additional-resources/cryocloud.md
@@ -1,0 +1,6 @@
+# CryoCloud
+
+The following page is rendered from https://book.cryointhecloud.com
+
+:::{embed} xref:cryocloud
+:::

--- a/myst.yml
+++ b/myst.yml
@@ -8,6 +8,9 @@ project:
   authors:
     - name: ICESat-2 team
   copyright: '2025'
+  references:
+    awesome: https://icesat-2hackweek.github.io/awesome-icesat2
+    cryocloud: https://book.cryointhecloud.com
   toc:
     - file: README.md
     - title: Preamble
@@ -31,6 +34,9 @@ project:
         - file: notebooks/inland-hydrology.ipynb
         - file: notebooks/bathymetry.ipynb
         - file: notebooks/snowdepth.ipynb
+    - title: Additional Resources
+      children:
+        - file: additional-resources.md
   jupyter:
       binder:
         url: https://hub.cryointhecloud.com

--- a/myst.yml
+++ b/myst.yml
@@ -36,7 +36,8 @@ project:
         - file: notebooks/snowdepth.ipynb
     - title: Additional Resources
       children:
-        - file: additional-resources.md
+        - file: additional-resources/awesome.md
+        - file: additional-resources/cryocloud.md
   jupyter:
       binder:
         url: https://hub.cryointhecloud.com

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,6 +14,7 @@ cookbook-dev = { features = ["plotting", "linting"], solve-group = "default" }
 [tasks]
 start = { cmd = "jupyter lab", cwd = "notebooks", description = "Start JupyterLab in the notebooks directory" }
 export-env = { cmd = "pixi workspace export conda-environment -e cookbook-dev > environment.yml", description = "Export workspace to a Conda environment file" }
+serve = "myst start"
 
 [dependencies]
 jupyterlab = "*"


### PR DESCRIPTION
I think one of the nicest features of myst is the ability to embed external content (and entire pages) - https://mystmd.org/guide/embed#embed-from-external-myst-projects. 

For example, it's possible to render any page or labelled content on the cryocloud jupyterbook here. And during the icesat-2 2025 hackweek we also updated an "awesome" list of icesat-2 resources. I've added those two landing pages in this PR to just test this functionality.